### PR TITLE
Ensure encoders are variational

### DIFF
--- a/src/configs/structured.yaml
+++ b/src/configs/structured.yaml
@@ -10,6 +10,7 @@ encoder_transformer:
   transformer_layer:
     _target_: models.utils.TransformerLayerConfig
     dropout_rate: 0.05
+  variational: true
 
 decoder_transformer:
   _target_: models.utils.DecoderTransformerConfig

--- a/src/models/structured_lpn.py
+++ b/src/models/structured_lpn.py
@@ -32,7 +32,7 @@ def poe_diag_gaussians(
         (mu, logvar): (*B, N, H)
     """
     precisions = jnp.exp(-logvars)
-    prior_prec = 1.0 - jnp.sum(alphas)
+    prior_prec = jnp.maximum(1.0 - jnp.sum(alphas), eps)
     a = alphas.reshape((-1,) + (1,) * (mus.ndim - 1))
     prec_sum = prior_prec + jnp.sum(a * precisions, axis=0)
     sigma = 1.0 / (prec_sum + eps)
@@ -386,33 +386,24 @@ class StructuredLPN(nn.Module):
         E = mus.shape[0]
         if E <= 1:
             return 0.0
-            
-        # Compute KL divergence between all pairs of encoders
-        # KL(p_i || p_j) where p_i and p_j are the latent distributions from encoders i and j
-        total_kl = 0.0
-        num_pairs = 0
-        
-        for i in range(E):
-            for j in range(i + 1, E):
-                # KL divergence between two Gaussian distributions
-                # KL(N(mu_i, var_i) || N(mu_j, var_j))
-                mu_i, mu_j = mus[i], mus[j]
-                var_i, var_j = jnp.exp(logvars[i]), jnp.exp(logvars[j])
-                
-                # KL divergence formula: 0.5 * (log(var_j/var_i) + var_i/var_j + (mu_i-mu_j)^2/var_j - 1)
-                kl_div = 0.5 * (
-                    jnp.log(var_j / (var_i + 1e-8)) + 
-                    var_i / (var_j + 1e-8) + 
-                    jnp.square(mu_i - mu_j) / (var_j + 1e-8) - 1.0
-                )
-                
-                # Average over batch and latent dimensions
-                kl_div = jnp.mean(kl_div)
-                total_kl += kl_div
-                num_pairs += 1
-        
-        # Return average KL divergence across all encoder pairs
-        return total_kl / max(num_pairs, 1)
+
+        var = jnp.exp(logvars)
+        mu_i = mus[:, None, ...]
+        mu_j = mus[None, :, ...]
+        var_i = var[:, None, ...]
+        var_j = var[None, :, ...]
+
+        kl_div = 0.5 * (
+            jnp.log(var_j / (var_i + 1e-8)) +
+            var_i / (var_j + 1e-8) +
+            jnp.square(mu_i - mu_j) / (var_j + 1e-8) - 1.0
+        )
+
+        kl_div = jnp.mean(kl_div, axis=tuple(range(2, kl_div.ndim)))
+        mask = jnp.triu(jnp.ones((E, E), dtype=kl_div.dtype), k=1)
+        total_kl = jnp.sum(kl_div * mask)
+        num_pairs = E * (E - 1) / 2.0
+        return total_kl / (num_pairs + 1e-8)
 
 
 

--- a/src/structured_train.py
+++ b/src/structured_train.py
@@ -180,6 +180,10 @@ def build_model_from_cfg(cfg: omegaconf.DictConfig) -> tuple[StructuredLPN, list
     # Prefer structured.model_config if provided to match artifact shapes
     mc = getattr(cfg.structured, "model_config", None)
     if mc is not None:
+        if not getattr(mc, "variational", False):
+            raise ValueError(
+                "Encoders must be variational; set structured.model_config.variational=true."
+            )
         enc_cfg = omegaconf.OmegaConf.create({
             "_target_": "models.utils.EncoderTransformerConfig",
             "max_rows": mc.max_rows,
@@ -215,6 +219,10 @@ def build_model_from_cfg(cfg: omegaconf.DictConfig) -> tuple[StructuredLPN, list
         dec = DecoderTransformer(hydra.utils.instantiate(dec_cfg))
     else:
         # Fallback to explicit encoder/decoder configs
+        if not getattr(cfg.encoder_transformer, "variational", False):
+            raise ValueError(
+                "Encoders must be variational; set encoder_transformer.variational=true."
+            )
         if cfg.training.get("mixed_precision", False):
             enc = EncoderTransformer(instantiate_config_for_mpt(cfg.encoder_transformer))
             dec = DecoderTransformer(instantiate_config_for_mpt(cfg.decoder_transformer))


### PR DESCRIPTION
## Summary
- enforce `variational: true` in structured training config to give encoders trainable log-variances
- validate at model build time that all encoders are variational, avoiding accidental deterministic loading

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1cc3834d4832fbfb15d41d5810170